### PR TITLE
Use assertEqual as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ tests =
     , it "does not miscalculate things" <|
         expect (2 + 2) notToBe 5
 
+    , it "compares two numbers" <|
+        expect (10 > 5) toBeTruthy
+
     , it "exemplifies more complex test cases" <|
         let
           expression = 2 + 2
@@ -47,11 +50,11 @@ tests =
     ]
 ```
 
-Right now, elm-test-bdd-style comes only with `toBe` and `notToBe`, but it is very easy to create your own matchers:
+Right now, elm-test-bdd-style comes only with `toBe`, `notToBe` and `toBeTruthy`, but it is very easy to create your own matchers:
 
 ```elm
-toBeGreaterThan : comparable -> comparable -> Bool
-toBeGreaterThan = (>)
+toBeGreaterThan : comparable -> comparable -> Assertion
+toBeGreaterThan a b = (a > b) |> toBeTruthy
 
 tests : Test
 tests =

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "BDD-style matchers for elm-test",
     "repository": "https://github.com/rogeriochaves/elm-test-bdd-style.git",
     "license": "MIT",

--- a/src/ElmTestBDDStyle.elm
+++ b/src/ElmTestBDDStyle.elm
@@ -1,28 +1,31 @@
 module ElmTestBDDStyle
-  (Test, describe, it
-  , expect, toBe, notToBe
+  (Test, Assertion, describe, it
+  , expect, toBe, notToBe, toBeTruthy
   , itAlways, expectThat, isTheSameAs, forEvery) where
 
 {-| BDD style functions for ElmTest
 
 # Tests
-@docs Test, describe, it
+@docs Test, Assertion, describe, it
 
 # Matchers
-@docs expect, toBe, notToBe
+@docs expect, toBe, notToBe, toBeTruthy
 
 # Property-based testing
 @docs itAlways, expectThat, isTheSameAs, forEvery
 
 -}
 
-import ElmTest exposing (Test, Assertion, suite, test, assertEqual, assertNotEqual)
+import ElmTest exposing (Test, suite, test, assert, assertEqual, assertNotEqual)
 import Check.Test as CheckTest
 import Check.Investigator exposing (Investigator)
 import Random exposing (initialSeed)
 
 {-| The basic unit of testability. -}
 type alias Test = ElmTest.Test
+
+{-| Assertion type, use that for building custom matchers -}
+type alias Assertion = ElmTest.Assertion
 
 {-| A group of related behaviours specs -}
 describe : String -> List Test -> Test
@@ -34,8 +37,8 @@ it = test
 
 {-| Expectation to actually run the test, it receives
 two values and try to match then with a matcher -}
-expect : a -> (a -> b -> Assertion) -> b -> Assertion
-expect actual matchs expected = actual `matchs` expected
+expect : a -> (a -> b) -> b
+expect actual matchs = matchs actual
 
 {-| Expect something to be equals something else -}
 toBe : a -> a -> Assertion
@@ -44,6 +47,10 @@ toBe = assertEqual
 {-| Expect something not to be equals something else -}
 notToBe : a -> a -> Assertion
 notToBe = assertNotEqual
+
+{-| Expect something to be true -}
+toBeTruthy : Bool -> Assertion
+toBeTruthy = assert
 
 {-| Words just to make the tests more idiomatic -}
 type Conjunction = Word

--- a/src/ElmTestBDDStyle.elm
+++ b/src/ElmTestBDDStyle.elm
@@ -16,7 +16,7 @@ module ElmTestBDDStyle
 
 -}
 
-import ElmTest exposing (Test, Assertion, suite, test, assert)
+import ElmTest exposing (Test, Assertion, suite, test, assertEqual, assertNotEqual)
 import Check.Test as CheckTest
 import Check.Investigator exposing (Investigator)
 import Random exposing (initialSeed)
@@ -34,16 +34,16 @@ it = test
 
 {-| Expectation to actually run the test, it receives
 two values and try to match then with a matcher -}
-expect : a -> (a -> b -> Bool) -> b -> Assertion
-expect actual matchs expected = assert <| actual `matchs` expected
+expect : a -> (a -> b -> Assertion) -> b -> Assertion
+expect actual matchs expected = actual `matchs` expected
 
 {-| Expect something to be equals something else -}
-toBe : a -> a -> Bool
-toBe = (==)
+toBe : a -> a -> Assertion
+toBe = assertEqual
 
 {-| Expect something not to be equals something else -}
-notToBe : a -> a -> Bool
-notToBe = (<<) not << toBe
+notToBe : a -> a -> Assertion
+notToBe = assertNotEqual
 
 {-| Words just to make the tests more idiomatic -}
 type Conjunction = Word

--- a/test/Example.elm
+++ b/test/Example.elm
@@ -2,9 +2,10 @@ module Example where
 
 import ElmTestBDDStyle exposing (..)
 import Check.Investigator exposing (..)
+import ElmTest exposing (Assertion, assert)
 
-toBeGreaterThan : comparable -> comparable -> Bool
-toBeGreaterThan = (>)
+toBeGreaterThan : comparable -> comparable -> Assertion
+toBeGreaterThan a b = assert (a > b)
 
 tests : Test
 tests =

--- a/test/Example.elm
+++ b/test/Example.elm
@@ -2,10 +2,9 @@ module Example where
 
 import ElmTestBDDStyle exposing (..)
 import Check.Investigator exposing (..)
-import ElmTest exposing (Assertion, assert)
 
 toBeGreaterThan : comparable -> comparable -> Assertion
-toBeGreaterThan a b = assert (a > b)
+toBeGreaterThan a b = (a > b) |> toBeTruthy
 
 tests : Test
 tests =
@@ -23,6 +22,9 @@ tests =
           expect expression toBe 4
 
     , it "compares two numbers" <|
+        expect (10 > 5) toBeTruthy
+
+    , it "compares two numbers with a custom matcher" <|
         expect 10 toBeGreaterThan 5
 
     , itAlways "ends up with the same list when reversing twice" <|


### PR DESCRIPTION
Now, instead of using elm-test's `assert`, the `toBe` matcher uses `assertEqual`, so you can see the difference between the expected and the actual value:

![captura de tela 2016-04-02 as 15 26 58](https://cloud.githubusercontent.com/assets/792201/14228389/b66d6480-f8e9-11e5-9356-f1e374548a85.png)

Additionally, `toBeTruthy` was added to help building custom matchers that just check if something is true. Unfortutately, elm-test doesn't allow you to use a custom matcher for the fail case.
